### PR TITLE
Updated README manual update automation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ version: 0.0.1
 #### Manual updates
 
 #### Setting up your own automations
+* [Crash0v3r1de Helium-RAK Nebra Update Tool](https://github.com/Crash0v3r1de/BalenaNebraUpdater) - .NET Core CLI update automation tool
 
 ## Branches
 


### PR DESCRIPTION
Added a reference to my https://github.com/Crash0v3r1de/BalenaNebraUpdater repo that can be used as a full auto update automation tool for the https://github.com/NebraLtd/helium-rak/ fleet repo

Figured it may be worth adding a reference to on the repo readme directly